### PR TITLE
using `splitext` instead of `split`

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -166,7 +166,7 @@ Note: some tags are present by default like EXIF version, FLASHPIX version etc a
 """
 function write_tags(filepath::AbstractString; img::AbstractArray, tags::Dict{String,String})
     # restricting filetype to .jpeg and .jpg
-    if (!(split(filepath,".")[2] in ["jpeg", "jpg"]))
+    if (!(splitext(filepath)[2] in (".jpeg", ".jpg")))
         throw(DomainError("Currently only jpeg and jpg files are supported for EXIF write operation."))
     end
 


### PR DESCRIPTION
One should use `splitext` instead of `split`, since using `split` fails if a `.` is present in the filename (e.g. hidden directory on `linux`):

```julia
julia> split("/foo/bar/.hidden/fig.jpg", ".")[2]
"hidden/fig"
julia> splitext("/foo/bar/.hidden/fig.jpg")[2]
".jpg"
```